### PR TITLE
Python script to print out the context, question, and predicted answer

### DIFF
--- a/write_factoid_answers.py
+++ b/write_factoid_answers.py
@@ -1,0 +1,36 @@
+import json
+import argparse
+
+parser = argparse.ArgumentParser(
+    description="Returns the context, question, and answer.",
+    add_help=True, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+parser.add_argument("--truth_filename",
+                    default="data-release/BioASQ-6b/test/Full-Abstract/BioASQ-test-factoid-6b-3.json",
+                    help="the path to the ground truth file")
+
+parser.add_argument("--predictions_filename",
+                    default="/tmp/factoid_output/predictions.json",
+                    help="the path to the predictions file")
+args = parser.parse_args()
+
+with open(args.truth_filename) as json_file2:
+    truths = json.load(json_file2)
+
+with open(args.predictions_filename) as json_file:
+    answers = json.load(json_file)
+
+for data in answers.items():
+
+    id = data[0]
+    answer = data[1]
+    print("ID: {}".format(id))
+    print("="*32)
+
+    for d in truths["data"][0]["paragraphs"]:
+        if d["qas"][0]["id"] == id:
+            question = d["qas"][0]["question"]
+            context = d["context"]
+            print("Context:\n********\n{}\n\nQuestion:\n*********\n{}\n\nPrediction:\n***********\n{}".format(context, question, answer))
+
+    print("\n\n")


### PR DESCRIPTION
I wanted a method to combine the prediction file with the original context and question. This script does that. So instead of just the ID and predicted answer you will get:

> ID: 5a72329e2dc08e987e000006_003
> ================================
> Context:
> ********
> Diagnosis of pneumoperitoneum on supine abdominal radiographs. A blinded, retrospective study was performed to determine the value of supine abdominal radiographs in diagnosing pneumoperitoneum. Supine films from 44 cases of pneumoperitoneum were randomly interspersed among supine films from 87 control subjects without free air, and the films were reviewed for the presence or absence of various signs of pneumoperitoneum, including Rigler's sign (gas on both sides of the bowel wall), the falciform ligament sign (gas outlining the falciform ligament), the football sign (gas outlining the peritoneal cavity), the inverted-V sign (gas outlining the medial umbilical folds), and the right-upper-quadrant gas sign (localized gas in the right upper quadrant). One or more of these signs were present in 26 cases (59%) of pneumoperitoneum, including the right-upper-quadrant gas sign in 18 cases (41%), Rigler's sign in 14 cases (32%), and the falciform ligament and football signs in one case each (2%). Unfortunately, there were frequent errors in the interpretation of the right-upper-quadrant gas sign and Rigler's sign, with a total of 11 false-positive cases (13%). Further analysis of the true-positive right-upper-quadrant gas signs showed that these gas collections were always triangular or linear with an inferolateral to superomedial orientation and, if triangular, a concave superolateral border. In the true-positive Rigler's signs, the bowel wall thickness ranged from 1 to 8 mm, whereas the false positives all had a bowel wall thickness of 1 mm or less. Proper interpretation of the various signs of pneumoperitoneum on supine films should lead to more accurate diagnosis of this condition.
> 
> Question:
> *********
> Falciform ligament sign is characteristic to which disease?
> 
> Prediction:
> ***********
> pneumoperitoneum

```
usage: write_factoid_answers.py [-h] [--truth_filename TRUTH_FILENAME]
                                [--predictions_filename PREDICTIONS_FILENAME]

Returns the context, question, and answer.

optional arguments:
  -h, --help            show this help message and exit
  --truth_filename TRUTH_FILENAME
                        the path to the ground truth file (default: data-
                        release/BioASQ-6b/test/Full-Abstract/BioASQ-test-
                        factoid-6b-3.json)
  --predictions_filename PREDICTIONS_FILENAME
                        the path to the predictions file (default:
  
```                      /tmp/factoid_output/predictions.json)